### PR TITLE
Calling net.Start with unpooled message name fix

### DIFF
--- a/APAnti/lua/autorun/server/sv_apanti.lua
+++ b/APAnti/lua/autorun/server/sv_apanti.lua
@@ -309,6 +309,7 @@ local function APAntiLoad()
 
 		local an,as,tn,ts = tostring(t.aname), tostring(t.asteam), tostring(t.tname), tostring(t.tsteam)
 
+		util.AddNetworkString( "sNotifyHit" )
 		net.Start("sNotifyHit")
 			net.WriteString(an)
 			net.WriteString(as)


### PR DESCRIPTION
https://github.com/LuaTenshi/GLua/issues/7
